### PR TITLE
Partial rewrite to better support parsing nested html

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,33 +25,34 @@ const PDFKitHTML = require('@shipper/pdfkit-html-simple'),
           <h5>H5</h5>
           <h6>H6</h6>
           <strong>This is bold</strong>
+          <b>This is also bold</b>
           <span class="underline">
             <strong>This is bold and underlined</strong>
           </span>
           <em>This is italic</em>
-          <span style="text-decoration: underline;">This is underlined</span>
+          <u>This is mispeled txt (underlined)</u>
+          <span style="text-decoration: underline;">This is also underlined</span>
           <span class="underline">This is also underlined</span>
+          <ins>This is inserted text (underlined)</ins>
+          <del>This is deleted text (strike-through)</del>
+          <s>This is inaccurate: red == blue, text (strike-through)</s>
+          <span style="text-decoration: line-through;">This is also strike-through</span>
+          <p><strong>This is bold text</strong><br>with a linebreak in a paragraph</p>
+          <p><strong>This is also bold text<br>with a linebreak in the bold tag</strong>in a paragraph</p>
+          <p><strong>This is also bold text</strong><br><strong>With another bold text after linebreak</strong> in a paragraph</p>
+          <div style="font-size: 2rem;"><p>This is a paragraph</p>in a div with font-size 2rem</div>
+          <div>This is a div</div>
+          <div style="font-size: 20px;">This is another div with font-size 20px</div>
+          <div style="font-size: 16px; margin-bottom: 3em;">This is another div with font-size 16px, margin-bottom 3em</div>
+          <div style="margin-bottom: 3rem;">This is another div with margin-bottom 3rem</div>
+          <div style="margin-bottom: 20px;">This is another div with margin-bottom 20px</div>
+          <div style="margin-bottom: 20pt;">This is another div with margin-bottom 20pt</div>
+          <div><a href="https://www.github.com" target="_blank">This is a link to https://www.github.com</a> in a div</div>
         </body>
     </html>
     `;
     
-PDFKitHTML.parse(html)
-    .then(function(transformations) {
-      // We now have an array of functions to invoke with a document
-    });
+PDFKitHTML.parse(html, document, options);
 ```
-
-The result of the promise being an array of functions, each of which expect one parameter, `document`, and 
-will return a promise resolving with that document
-
-To apply the transformations to the document you can do something like this:
-
-```js
-const promise = transformations.reduce(function(promise, transformation) {
-  return promise.then(transformation);
-}, Promise.resolve(document));
-```
-
-Once the promise is resolved all transformations will be complete and you will have your document.
 
 See [examples/simple](examples/simple) for example usage

--- a/examples/simple/example.html
+++ b/examples/simple/example.html
@@ -33,11 +33,28 @@
   <h5>H5</h5>
   <h6>H6</h6>
   <strong>This is bold</strong>
+  <b>This is also bold</b>
   <span class="underline">
     <strong>This is bold and underlined</strong>
   </span>
   <em>This is italic</em>
-  <span style="text-decoration: underline;">This is underlined</span>
+  <u>This is mispeled txt (underlined)</u>
+  <span style="text-decoration: underline;">This is also underlined</span>
   <span class="underline">This is also underlined</span>
+  <ins>This is inserted text (underlined)</ins>
+  <del>This is deleted text (strike-through)</del>
+  <s>This is inaccurate: red == blue, text (strike-through)</s>
+  <span style="text-decoration: line-through;">This is also strike-through</span>
+  <p><strong>This is bold text</strong><br>with a linebreak in a paragraph</p>
+  <p><strong>This is also bold text<br>with a linebreak in the bold tag</strong>in a paragraph</p>
+  <p><strong>This is also bold text</strong><br><strong>With another bold text after linebreak</strong> in a paragraph</p>
+  <div style="font-size: 2rem;"><p>This is a paragraph</p>in a div with font-size 2rem</div>
+  <div>This is a div</div>
+  <div style="font-size: 20px;">This is another div with font-size 20px</div>
+  <div style="font-size: 16px; margin-bottom: 3em;">This is another div with font-size 16px, margin-bottom 3em</div>
+  <div style="margin-bottom: 3rem;">This is another div with margin-bottom 3rem</div>
+  <div style="margin-bottom: 20px;">This is another div with margin-bottom 20px</div>
+  <div style="margin-bottom: 20pt;">This is another div with margin-bottom 20pt</div>
+  <div><a href="https://www.github.com" target="_blank">This is a link to https://www.github.com</a> in a div</div>
 </body>
 </html>

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,6 @@
 const Parse = require('parse5'),
   Cheerio = require('cheerio'),
   CSS = require('css'),
-  EventEmitter = require('events'),
   FS = require('fs'),
   Path = require('path');
 
@@ -41,14 +40,25 @@ function loadDefaultStyle(name) {
 
 /**
  * @param {string|Buffer} html
+ * @param {PDFKit.PDFDocument} pdfdocument
  * @param {{}} [options={}]
  * @returns {Promise}
  */
-exports.parse = function(html, options) {
-
+exports.parse = function(html, pdfdocument, options) {
   if(!('string' === typeof html || Buffer.isBuffer(html))) {
     throw new Error('html must be a string or buffer');
-  } else {
+  }
+  if(!pdfdocument || typeof pdfdocument.text !== 'function') {
+    throw new Error('pdfdocument must be an instance of pdfkit document');
+  }
+
+  if (options && options.style && options.style.length > 0) {
+    defaultStylesheets.push(
+      {
+        name: 'style',
+        text: options.style
+      }
+    )
   }
 
   const document = Parse.parse(
@@ -56,15 +66,43 @@ exports.parse = function(html, options) {
     {
       treeAdapter: Parse.treeAdapters.htmlparser2
     }
-  ),
-    nodes = exports.listen(document);
-
-  const transformations = exports.convertNodesToTransformations(nodes, options);
-
-  return Promise.resolve(
-    transformations
   );
+
+  iterateNodeChildren(document, pdfdocument, options);
+
+  return document;
 };
+
+function iterateNodeChildren(node, document, options) {
+  if (node.type === 'text' || (node.type === 'tag' && node.name === 'br')) {
+    exports.renderNode(
+      {
+        ...node,
+        parentNode: node.parentNode,
+        nextNode: node.nextNode
+      },
+      document,
+      options
+    );
+  }
+
+  if(!(node.childNodes instanceof Array)) {
+    return;
+  }
+
+  node
+    .childNodes
+    .forEach(function(childNode, index) {
+      childNode.parentNode = node;
+      childNode.nextNode = (
+        node.childNodes.length > index + 1 ?
+        node.childNodes[index + 1] :
+        undefined
+      );
+
+      return iterateNodeChildren(childNode, document, options);
+    });
+}
 
 exports.transformHTML = function(html) {
   const $ = Cheerio.load(html);
@@ -191,172 +229,21 @@ exports.decorateCSS = function($, style, source) {
 
 };
 
-exports.emitNodes = function(emitter, node, level, index) {
-  level = level || 0;
-  index = index || 0;
-
-  node.id = `level(${level}) index(${index}) parent(${node.parentNode && node.parentNode.id || ''}) ${node.tagName || node.nodeName}`;
-  node.level = level;
-
-  if(!node.tagName) {
-    return iterateChildren(node);
-  }
-
-  emitter.emit('startTag', node.tagName, node.id, node.parentNode && node.parentNode.id, node.attribs, node.level);
-
-  iterateChildren(node, true);
-
-  emitter.emit('endTag', node.id, node.parentNode && node.parentNode.id, node.attrs);
-
-  function iterateChildren(node, taggedElement) {
-    if(!(node.childNodes instanceof Array)) {
-      return;
-    }
-
-    if(taggedElement && node.childNodes.length === 1 && node.childNodes[0].type === 'text') {
-      return emitter.emit('text', node.id, node.childNodes[0].data || '');
-    }
-
-    node
-      .childNodes
-      .forEach(function(childNode, index) {
-        childNode.parentNode = node;
-        return exports.emitNodes(emitter, childNode, level + 1, index);
-      });
-  }
-};
-
-exports.listen = function(document) {
-
-  // const objects = [];
-  // console.log(JSON.stringify(document, function(key, value) {
-  //   if(!(value instanceof Object)) {
-  //     return value;
-  //   }
-  //   if(objects.indexOf(value) === -1) {
-  //     objects.push(value);
-  //     return value;
-  //   }
-  //   return undefined;
-  // }, '  '));
-
-  let result = [];
-
-  const elements = {};
-
-  const emitter = new EventEmitter();
-
-  emitter.on('startTag', startTag);
-
-  emitter.on('endTag', endTag);
-
-  emitter.on('text', function(id, text) {
-    elements[id] = (elements[id] || [{ id }]);
-    elements[id][elements[id].length - 1].text = text;
-  });
-
-  exports.emitNodes(emitter, document);
-
-  emitter.emit('finish');
-
-  // We only want text nodes
-  result = result
-    .filter(function(node) {
-      return node.text;
-    });
-
-  result
-    .forEach(function(node, index, array) {
-      const previous = array[index - 1];
-      if(!previous) {
-        return;
-      }
-      previous.nextNode = node;
-    });
-
-  // stack.forEach(function(stack) {
-  //   endTag(stack.tagName);
-  // });
-
-  // console.log(result);
-
-  return result;
-
-  function startTag(name, id, parentId, attributes, level) {
-    const parentStack = elements[parentId] || [];
-
-    elements[id] = parentStack.concat(elements[id] || []).concat({
-      id: id,
-      tagName: name,
-      attributes,
-      level
-    });
-
-  }
-
-  function endTag(id) {
-    if(!elements[id]) {
-      return;
-    }
-
-    const current = elements[id][elements[id].length - 1];
-
-    const object = elements[id].reduce(function(object, current) {
-      return Object.assign({}, object, current, {
-        attributes: (object.attributes || [])
-          .map(function(attribute) {
-            return Object.assign({}, attribute, {
-              inherited: true
-            });
-          })
-          .concat(
-            Object.keys(current.attributes || {})
-              .map(function(key) {
-                return {
-                  name: key,
-                  value: current.attributes[key],
-                  level: current.level
-                };
-              })
-          ),
-        tagNames: (object.tagNames || []).concat(current.tagName)
-      });
-    }, {});
-
-    result
-      .filter(function(node) {
-        return node.id === current.id;
-      })
-      .forEach(function(node) {
-        node.parentNode = object;
-      });
-
-    result.push(
-      object
-    );
-
-    elements[id] = undefined;
-  }
-};
-
-exports.convertNodesToTransformations = function(nodes, options) {
-  return nodes.reduce(function(transformations, node) {
-    return transformations.concat(
-      exports.convertNodeToTransformations(node, options)
-    );
-  }, []);
-};
-
 exports.getStylesForNode = function(node, options) {
   if(node.styles) {
     return node.styles;
   }
 
-  const styleAttributes = node.attributes
+  const attributes = Object.keys(node.attribs || {}).map((key) => ({
+    name: key,
+    value: node.attribs[key]
+  }));
+
+  const styleAttributes = attributes
     .filter(function(attribute) {
       return attribute.name === 'style';
     });
-  const declarationAttributes = node.attributes
+  const declarationAttributes = attributes
     .filter(function(attribute) {
       return attribute.name === 'data-declarations';
     });
@@ -433,81 +320,227 @@ exports.getStylesForNode = function(node, options) {
 
 };
 
-exports.convertNodeToTransformations = function(node, options) {
-
-  const styles = exports.getStylesForNode(node, options),
+exports.renderNode = function(node, document, options) {
+  let styles = exports.getStylesForNode(node, options),
+    parentStyles = node.parentNode ? exports.getStylesForNode(node.parentNode, options) : {},
     nextStyles = node.nextNode ? exports.getStylesForNode(node.nextNode, options) : {};
 
-  const transformations = [],
-    font = {
-      bold: false,
-      italic: false
-    };
+  let parentNodes = [];
+  let parentNode = node;
+  while (parentNode) {
+    if (parentNode.name || (parentNode.attribs && Object.keys(parentNode.attribs).length > 0)) {
+      parentNodes.push(parentNode);
+    }
+    parentNode = parentNode.parent;
+  }
+
+  parentNodes = parentNodes.reverse();
+  const tagNames = parentNodes.filter(v => v.name).map(v => v.name);
+  const aryStyles = parentNodes.filter(v => v.attribs && Object.keys(v.attribs).length > 0).map(v =>
+    exports.getStylesForNode(
+      v,
+      options
+    )
+  );
+
+  const font = {
+    bold: false,
+    italic: false
+  };
 
   let textOptions = {
-    continued: isContinued(styles) && isContinued(nextStyles)
+    continued: isContinued(styles) &&
+               isContinued(nextStyles) &&
+               (isContinued(parentStyles) || node.nextNode) &&
+               (!node.nextNode || node.nextNode.type !== 'tag' || node.nextNode.name !== 'br')
   };
-  
-  // console.log(node);
 
   function isContinued(currentStyles) {
     return currentStyles['display'] === 'inline' || currentStyles['display'] === 'inline-block' || !currentStyles['display']
   }
 
-  textOptions.underline = styles['text-decoration'] === 'underline';
+  styles = Object.assign({}, ...aryStyles);
+
+  textOptions.underline = (
+    styles['text-decoration'] === 'underline' ||
+    tagNames.indexOf('u') > -1 ||
+    tagNames.indexOf('ins') > -1
+  );
 
   font.bold = (
     styles['font-weight'] === 'bold' ||
-    styles['font-weight'] === 'bolder'
+    styles['font-weight'] === 'bolder' ||
+    // (!isNaN(Number(styles['font-weight'])) && Number(styles['font-weight']) >= 700) ||
+    tagNames.indexOf('b') > -1 ||
+    tagNames.indexOf('strong') > -1
   );
-
-  // console.log(node);
 
   if(styles['font-weight'] && !isNaN(+styles['font-weight'].trim())) {
     font.weight = +styles['font-weight'].trim();
   }
 
   //i, cite, em, var, address, dfn
-  font.italic = styles['font-style'] === 'italic';
+  font.italic = (
+    styles['font-style'] === 'italic' ||
+    tagNames.indexOf('i') > -1 ||
+    tagNames.indexOf('em') > -1
+  );
 
-  textOptions.stroke = node.tagNames.indexOf('del') > -1;
+  textOptions.strike = (
+    styles['text-decoration'] === 'line-through' ||
+    tagNames.indexOf('s') > -1 ||
+    tagNames.indexOf('del') > -1
+  );
 
-  transformations.push(function(document) {
-    // console.log(font, node.text);
-    exports.setFont(document, node, font, styles, options);
+  // TODO: cannot be included until the pdfkit issue about text align and continued is solved:
+  // see: https://github.com/foliojs/pdfkit/issues/774
+  // if (['left', 'center', 'right', 'justify'].indexOf(styles['text-align']) > -1) {
+  //   textOptions.align = styles['text-align'];
+  // }
+  // else {
+  //   textOptions.align = null;
+  // }
 
-    if(styles['color']) {
-      document.fillColor(styles['color'], isNaN(+styles['opacity']) ? 1 : +styles['opacity']);
+  const linkIdx = parentNodes.map(v => v.name).lastIndexOf('a');
+  if (linkIdx > -1) {
+    textOptions.link = parentNodes[linkIdx].attribs['href'];
+    if (!styles['color']) {
+      styles['color'] = (
+        options && options.colors && options.colors.link ?
+        options.colors.link :
+        'blue'
+      );
     }
+  }
+  else {
+    textOptions.link = null;
+    if (!styles['color']) {
+      styles['color'] = (
+        options && options.colors && options.colors.base ?
+        options.colors.base :
+        'black'
+      );
+    }
+  }
 
-    document.text(node.text ? node.text + ' ' : '', textOptions);
+  // console.log(font, node.text);
+  exports.setFont(document, node, font, styles, options);
 
-    return Promise.resolve(document);
-  });
+  if(styles['color']) {
+    document.fillColor(styles['color'], isNaN(+styles['opacity']) ? 1 : +styles['opacity']);
+  }
 
-  return transformations;
+  if (node.type === 'tag' && node.name === 'br') {
+    // NOTE: if the previous node is text,
+    // then we already handled the linebreak by setting continued:false on that text
+    // it's the only way to make it behave like it should
+    if (!node.prev || node.prev.type !== 'text') {
+      document.text('\n', {continued: false});
+    }
+  }
+  else if (node.type === 'text') {
+    if (node.data && node.data.substring(0, 2) === '\n') {
+      let text = node.data;
+      if (node.prev) {
+        let prevstyles = exports.getStylesForNode(
+          node.prev,
+          options
+        );
+        if (prevstyles && !isContinued(prevstyles)) {
+          text = node.data.substring(1);
+        }
+      }
+      if (text) {
+        document.text(text || '', textOptions);
+      }
+    }
+    else {
+      document.text(node.data || '', textOptions);
+    }
+  }
+
+  if (node.parentNode && node.parentNode.type === 'tag' && !node.nextNode && parentStyles && (parentStyles['margin'] || parentStyles['margin-bottom'])) {
+    let marginBottom;
+    if (parentStyles['margin']) {
+      let margins = parentStyles['margin'].split(' ');
+      switch (margins.length) {
+        case 1:
+          marginBottom = margins[0];
+          break;
+        case 2:
+          marginBottom = margins[0];
+          break;
+        case 3:
+          break;
+        case 4:
+          marginBottom = margins[2];
+          break;
+        case 5:
+          marginBottom = margins[2];
+          break;
+      }
+    }
+    if (parentStyles['margin-bottom']) {
+      marginBottom = parentStyles['margin-bottom'];
+    }
+    if (marginBottom) {
+      const match = marginBottom.match(new RegExp(/^(-?[\d.]+)(px|pt|em|rem|%)?(?:[ ]*!important)?$/));
+      if (match) {
+        const [m1, val, unit] = match;
+        let moveValue = (val && !unit ? val : 0);
+        if (val && !isNaN(Number(val)) && unit) {
+          const pxToPoint = 0.75;
+          switch (unit) {
+            case 'px':
+              moveValue = (Number(val) * pxToPoint) / Number(exports.getFontSize(node, styles, options));
+              break;
+            case 'pt':
+              moveValue = Number(val) / Number(exports.getFontSize(node, styles, options));
+              break;
+            case 'em':
+              moveValue = Number(val);
+              break;
+            case 'rem':
+              moveValue = Number(val) * (Number(exports.getFontSize(node, {}, options)) / Number(exports.getFontSize(node, styles, options)));
+              break;
+            // case '%': // ignore this?
+            //   break;
+          }
+        }
+        if (moveValue) {
+          document.moveDown(moveValue);
+        }
+      }
+    }
+  }
 };
 
 exports.setFont = function(document, node, font, styles, options) {
   const details = exports.getFont(document, font, styles, options),
-    size = exports.getFontSize(node, styles);
+    size = exports.getFontSize(node, styles, options);
 
   document.font(details.source, size);
 };
 
-exports.getFontSize = function(node, styles) {
-  const size = exports.getFontSizeBase(node, styles),
+exports.getFontSize = function(node, styles, options) {
+  const size = exports.getFontSizeBase(node, styles, options),
     base = 10000;
   return Math.ceil(size * base) / base;
 };
 
-exports.getFontSizeBase = function(node, styles) {
+exports.getFontSizeBase = function(node, styles, options) {
 
-  const coreSize = 12,
+  const baseSize = 12,
     fontScale = 4;
 
+  const coreSize = (
+    options && options.fontSizes ?
+    options.fontSizes.base :
+    baseSize
+  );
+
   const base = node.previousNode && node.previousNode.styles ?
-    exports.getFontSizeBase(node.previousNode, node.previousNode.styles) :
+    exports.getFontSizeBase(node.previousNode, node.previousNode.styles, options) :
     coreSize;
 
   let fontSize = styles['font-size'];
@@ -626,7 +659,7 @@ exports.getFontName = function(document, styles, options) {
     return baseFont;
   }
 
-  const font = styles['font-family'];
+  const font = styles['font-family'] || '';
 
   return font.split(/\s*,\s*/g)
     .map(function(fontName) {
@@ -636,7 +669,7 @@ exports.getFontName = function(document, styles, options) {
     })
     .find(function(fontName) {
       return options.fonts[fontName];
-    }) || baseFont;
+    }) || Object.keys(options.fonts)[0] || baseFont;
 };
 
 exports.getInheritedStyles = function() {


### PR DESCRIPTION
The previous version had alot of limitations, due to flattening the tree before rendering, which meant it became almost impossible to figure out which text content belongs to which block. For example if there are two paragraph blocks, with inner tags, how do you know when each paragraph block ends, if they are at the same level?

This commit adds support for:
* Linebreaks (`<br>`).
* Paragraphs (`<p>`) or divs (`<div>`) with some styled text and some unstyled text (for example some text inside `<strong>` tags and some just regular text).
* Bottom margins on tags, such as paragraphs, headings, etc.
* Links `<a href="">`.
* More text styling tags: `<u>, <ins>, <b>, <strong>, <i>, <em>, <s>`.
* More text styling css: `text-decoration: line-through;`
* Bottom margin css from either `margin` or `margin-bottom`.
* Custom css styles through the optional `options.style` parameter.
* Override base fonts/fontsize through the optional `options.fonts`/`options.fontSizes.base` parameters.
* Override base color and link color through the optional `options.colors.base`/`options.colors.link` parameters.

Library is now no longer asyncrounous, there seem to be no need for that anymore.
The transformations handling is also removed, as there seem to be no need for that either, now that the flattening of the html through events has been replaced with a tree parser instead.

If there is a good reason for having the transformations, and events, please let me know.
But I simply could not get the tree parsing to work properly when using the flattening events and transformations.